### PR TITLE
change travis scripts to rails new specification

### DIFF
--- a/travis.yml
+++ b/travis.yml
@@ -4,8 +4,8 @@ rvm:
 services:
   - postgresql
 script: 
-  - RAILS_ENV=test bundle exec rake db:migrate --trace
-  - bundle exec rake db:test:prepare
+  - RAILS_ENV=test bundle exec rails db:migrate --trace
+  - bundle exec rails db:test:prepare
   - bundle exec rspec spec/
 before_script:
   - psql -c 'create database gearbay_test;' -U ubuntu


### PR DESCRIPTION
For testing travis only.

Just change the scripts to rails 5.0.0 as the tasks have been migrated under rails namespace from under rake in the current version